### PR TITLE
Add API changes for Citadel 0.1.0

### DIFF
--- a/src/manager/auth.ts
+++ b/src/manager/auth.ts
@@ -133,14 +133,14 @@ export class ManagerAuth extends ApiConnection {
     username: string,
     password: string,
     seed: string[],
-  ): Promise<string> {
-    const data = await this.post<{jwt?: string}>('register', {
+  ): Promise<{jwt: string, backupId?: string}> {
+    const data = await this.post<{jwt?: string, backupId?: string}>('register', {
       seed,
       password,
       name: username,
     });
     if (!data.jwt) throw new Error('Failed to register new user.');
-    return data.jwt;
+    return data as {jwt: string, backupId?: string};
   }
 
   /**

--- a/src/manager/system.ts
+++ b/src/manager/system.ts
@@ -104,8 +104,12 @@ export class ManagerSystem extends ApiConnection {
       .externalStorage;
   }
 
+  async getUpdateChannel(channel: string): Promise<void> {
+    return (await this.get<{channel: string}>('update-channel')).channel;
+  }
+
   async setUpdateChannel(channel: string): Promise<void> {
-    return this.put('uptime', {
+    return this.put('update-channel', {
       channel,
     });
   }

--- a/src/manager/system.ts
+++ b/src/manager/system.ts
@@ -104,6 +104,12 @@ export class ManagerSystem extends ApiConnection {
       .externalStorage;
   }
 
+  async setUpdateChannel(channel: string): Promise<void> {
+    return this.put('uptime', {
+      channel,
+    });
+  }
+
   async isCitadelOS(): Promise<boolean> {
     return (await this.get<{os: 'Citadel' | 'unknown'}>('/')).os === 'Citadel';
   }


### PR DESCRIPTION
This adds some new methods for Citadel 0.1.0. The new things will be inaccessible/throw with older versions, but any existing methods will not break.

However, the return type of register changes with this.