### PR TITLE
fix: set onAuthFailed for reqs to lightning

### DIFF
--- a/src/middleware/lnd.ts
+++ b/src/middleware/lnd.ts
@@ -45,6 +45,16 @@ export class MiddlewareLND extends ApiConnection {
         requestFunc;
   }
 
+  public set onAuthFailed(callback: (url: string) => void) {
+    this.channel.onAuthFailed =
+      this.info.onAuthFailed =
+      this.lightning.onAuthFailed =
+      this.transaction.onAuthFailed =
+      this.wallet.onAuthFailed =
+      this._onAuthFailed =
+        callback;
+  }
+
   public async address(): Promise<NewAddressResponse> {
     return await this.get<NewAddressResponse>('address');
   }
@@ -54,6 +64,7 @@ export class MiddlewareLND extends ApiConnection {
       await this.post<{signature: string}>('util/sign-message', {message})
     ).signature;
   }
+
   public async validateMessage(
     message: string,
     signature: string,


### PR DESCRIPTION
Forgot to set the handler for some LND derived classes. Practically the 401 handler will fire somewhere else and the user will be redirected, so no need to version this now.